### PR TITLE
Fix an error when git status shows other than "add" and "modify"

### DIFF
--- a/_run_local-hook.sh
+++ b/_run_local-hook.sh
@@ -12,7 +12,7 @@ fi
 # Function
 function detect_no-break-space(){
   file_arr=(
-    $( git status -s | cut -c4- )
+    $( git status -s | grep -E "^ *(A|M)" | cut -c4- )
   )
   for file in "${file_arr[@]}" ; do
     # File exsistence check


### PR DESCRIPTION
# Overview
When git status includes the following files/directories status, `_run_local-hook.sh` shows "No such file" errors and aborts.

- Removed
- Unstaged